### PR TITLE
`RetweetText`というFunction名の変更

### DIFF
--- a/app/src/main/java/io/github/akiomik/seiun/ui/timeline/FeedPost.kt
+++ b/app/src/main/java/io/github/akiomik/seiun/ui/timeline/FeedPost.kt
@@ -32,7 +32,7 @@ import java.time.Instant
 
 // リポストされている投稿
 @Composable
-private fun RetweetText(viewPost: FeedViewPost) {
+private fun RepostText(viewPost: FeedViewPost) {
     Box(modifier = Modifier.padding(bottom = 8.dp)) {
         Text(
             text = "Reposted by ${viewPost.reason?.by?.displayName}",
@@ -241,7 +241,7 @@ private fun FeedPostContent(viewPost: FeedViewPost) {
 fun FeedPost(viewPost: FeedViewPost) {
     Column(modifier = Modifier.padding(10.dp)) {
         if (viewPost.reason?.type == "app.bsky.feed.feedViewPost#reasonRepost") {
-            RetweetText(viewPost = viewPost)
+            RepostText(viewPost = viewPost)
         } else if (viewPost.reply != null) {
             ReplyText(viewPost = viewPost)
         }


### PR DESCRIPTION
AT Protocolでは、`Post`という単語が使われているためFunction名を`RetweetText`ではなく、`RepostText`へ変更したい
Close #3 